### PR TITLE
Drop se_node target dependency already linked.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,6 @@ target_link_libraries(
 
 ament_target_dependencies(
   se_node
-  ${library_name}
   ${dependencies}
 )
 


### PR DESCRIPTION
Precisely what the title says. This was preventing me from building this package locally for Eloquent and it'd seem to me it's already been covered by [`target_link_libraries()` above](https://github.com/mabelzhang/robot_localization/compare/dashing-devel...hidmic:hidmic/fix-CMakeLists.txt?expand=1#diff-af3b638bc2a3e6c650974192a53c7291R93-R96).